### PR TITLE
fix: Correct display property value in style attribute to resolve CSS…

### DIFF
--- a/src/client/components/CodeSwitcher.ts
+++ b/src/client/components/CodeSwitcher.ts
@@ -122,6 +122,7 @@ export const CodeSwitcher = defineComponent({
               {
                 class: 'tab-content',
                 key: shorthand,
+                style: { display: $slots[shorthand] ? 'block' : 'none' },
               },
               ($slots[shorthand] || slotNotFound)({ shorthand })
             ),


### PR DESCRIPTION
This pull request addresses a CSS parse error reported by the W3C Validator. The issue was related to an incorrect display property value in the style attribute. The fix ensures that the display property is properly set in the style attribute, resolving the parse error. This modification enhances the code switcher's compatibility with W3C standards.